### PR TITLE
Corrected version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "com.rel.languager"
         minSdk 21
         targetSdk 33
-        versionCode 5
-        versionName "1.0"
+        versionCode 6
+        versionName "1.1.0"
     }
 
     buildTypes {


### PR DESCRIPTION
Your v1.1.0 release still uses the v1.0 version number, which causes updates to always be displayed when checking for updates from the Xposed repository.

So I increased both the version number and the version code by 1, hoping that would fix the issue